### PR TITLE
Add option to use qemu built in wsl

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -150,11 +150,11 @@ echo "[Replacing strings]"
 sed -i "s!\[THREADS_COUNT\]!$THREADS_COUNT!g" "$TEMP/build.sh"
 sed -i "s!\[HDD_SIZE\]!$HDD_SIZE!g" "$TEMP/build.sh"
 if test $WSL -eq 1; then
-	sed -i "s!\[QEMU_PATH\]! \\\\\"/mnt/c/Windows/system32/cmd.exe\\\\\" /c  \\ \\\\\"$QEMU_PATH\\\\\"!g" "$TEMP/tasks.json"
+	sed -i "s!\[QEMU_PATH\]! \\\\\"/mnt/c/Windows/system32/cmd.exe\\\\\" /c  \\ \\\\\"$QEMU_PATH\\\\\"!g" "$TEMP/runQemu.sh"
 elif test $NE -eq 1; then
-	sed -i "s!\[QEMU_PATH\]! export DISPLAY=:0 | $QEMU_PATH!g" "$TEMP/tasks.json"
+	sed -i "s!\[QEMU_PATH\]! export DISPLAY=:0 | $QEMU_PATH!g" "$TEMP/runQemu.sh"
 else
-	sed -i "s!\[QEMU_PATH\]!$QEMU_PATH!g" "$TEMP/tasks.json"
+	sed -i "s!\[QEMU_PATH\]!$QEMU_PATH!g" "$TEMP/runQemu.sh"
 fi
 echo "[Done]"
 
@@ -163,8 +163,11 @@ echo "[Preparing workspace directory]"
 mkdir -p "$WORK_DIR/build/"
 mkdir -p "$WORK_DIR/scripts/"
 cp "$TEMP/build.sh" "$WORK_DIR/scripts/"
+cp "$TEMP/runQemu.sh" "$WORK_DIR/scripts/"
+cp "$TEMP/findBinaries.sh" "$WORK_DIR/scripts/"
 mkdir -p "$WORK_DIR/.vscode/"
 cp "$TEMP/launch.json" "$WORK_DIR/.vscode/"
+cp "$TEMP/launch.json" "$WORK_DIR/scripts/"
 cp "$TEMP/tasks.json" "$WORK_DIR/.vscode/"
 echo "[Done]"
 

--- a/findBinaries.sh
+++ b/findBinaries.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+env=$(find environment/ -name '*.elf')
+os=$(find os/ -name '*.elf')
+
+DEBUG_PATHS=""
+COUNT=0
+
+#read os
+while IFS= read -r line; do
+    if [ -n "$DEBUG_PATHS" ]; then
+        DEBUG_PATHS="${DEBUG_PATHS},\"/${line}\""
+    else
+        DEBUG_PATHS="\"/${line}\""
+    fi
+	((COUNT=COUNT+1))
+done <<< "$os"
+
+
+#read env
+while IFS= read -r line; do
+    if [ -n "$DEBUG_PATHS" ]; then
+        DEBUG_PATHS="${DEBUG_PATHS},\"/${line}\""
+    else
+        DEBUG_PATHS="\"/${line}\""
+    fi
+	((COUNT=COUNT+1))
+done <<< "$env"
+#[DEBUG_PATHS]
+
+cp "scripts/launch.json" ".vscode/launch.json"
+sed -i "s!\[DEBUG_PATHS\]!$DEBUG_PATHS!g" ".vscode/launch.json"
+
+echo "Found: $COUNT files"

--- a/launch.json
+++ b/launch.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.0",
+    "version": "2.1.0",
     "configurations": [
         {
             "name": "Launch with GDB",
@@ -28,7 +28,6 @@
                     "text": "file ${workspaceFolder}${input:debuggerTarget}",
                     "description": "Load binary."
                 }
-
             ],
             "preLaunchTask": "Run QEMU with debugger"
         }
@@ -36,8 +35,9 @@
     "inputs": [
         {
             "id": "debuggerTarget",
-            "type": "promptString",
+            "type": "pickString",
             "description": "What do you want to debug?",
+            "options":[ [DEBUG_PATHS] ],
             "default": "/os/kernel/bin/kernel.elf"
         }
     ]

--- a/runQemu.sh
+++ b/runQemu.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+if test $# -eq 0; then
+	echo "Mode not specified"
+	exit 1
+fi
+
+while test $# -gt 0; do
+	case "$1" in
+		-debug)
+			DEBUG=1
+            shift
+			;;
+		-run)
+			RUN=1
+            shift
+            ;;
+	esac
+done
+
+if [ $DEBUG -eq 1 ]; then
+qemu-system-i386 -m 640M\
+ -monitor stdio \
+ -drive file=build/floppy.img,format=raw,if=floppy\
+ -drive file=build/hdd.img,format=raw -boot a -S -s\
+ -netdev user,id=u1,hostfwd=tcp::5555-:22\
+ -device rtl8139,netdev=u1\
+ -object filter-dump,id=f1,netdev=u1,file=dump.dat
+fi
+
+
+if [ $RUN -eq 1 ]; then
+qemu-system-i386 -m 640M\
+ -drive file=build/floppy.img,format=raw,if=floppy\
+ -drive file=build/hdd.img,format=raw -boot a -soundhw pcspk\
+ -netdev user,id=u1,hostfwd=tcp::5555-:22\
+ -device rtl8139,netdev=u1
+fi

--- a/tasks.json
+++ b/tasks.json
@@ -1,13 +1,23 @@
 {
-    "version": "2.0.0",
+    "version": "2.1.0",
     "tasks": [
         {
             "label": "Clean",
             "type": "shell",
             "command": "${workspaceFolder}/scripts/build.sh",
-			"args": [
-				"clean"
-			],
+            "args": [
+                "clean"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Look for binary files",
+            "type": "shell",
+            "command": "${workspaceFolder}/scripts/findBinaries.sh",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -27,7 +37,7 @@
         {
             "label": "Run QEMU",
             "type": "shell",
-            "command": "echo \"Starting QEMU\" & [QEMU_PATH] -m 640M -drive file=build/floppy.img,format=raw,if=floppy -drive file=build/hdd.img,format=raw -boot a -soundhw pcspk",
+            "command": "echo \"Starting QEMU\" & ${workspaceFolder}/scripts/runQemu.sh -run",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -51,7 +61,7 @@
         {
             "label": "Run QEMU with debugger",
             "type": "shell",
-            "command": "echo \"Starting QEMU\" & [QEMU_PATH] -m 640M -drive file=build/floppy.img,format=raw,if=floppy -drive file=build/hdd.img,format=raw -boot a -S -s",
+            "command": "echo \"Starting QEMU\" & ${workspaceFolder}/scripts/runQemu.sh -debug",
             "group": {
                 "kind": "build",
                 "isDefault": true


### PR DESCRIPTION
New option for debugging, allows using qemu installed in wsl.
Requirements: 
- in wsl:  installed qemu, qemu-system-i386 gedit 
- in host(windows 10): installed X server eg.  [VcSrv](https://sourceforge.net/projects/vcxsrv/) - [tutorial](https://techcommunity.microsoft.com/t5/windows-dev-appconsult/running-wsl-gui-apps-on-windows-10/ba-p/1493242)
Before debugging run VcSrv just like in [tutorial](https://techcommunity.microsoft.com/t5/windows-dev-appconsult/running-wsl-gui-apps-on-windows-10/ba-p/1493242)

When using emulator built in, there is no point to use -q and --wsl options